### PR TITLE
feat: assert paid license for cron usage

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,9 @@
+---
+profile: production
+
+exclude_paths:
+  - .git/
+  - .github/
+  - .ansible/
+  - .vscode/
+  - venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .vscode
 .DS_Store
+.ansible

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v25.4.0
+    hooks:
+      - id: ansible-lint

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ ecomscan_run: true
 Boolean to set if ecomscan should execute during the playbook execution. 
 
 ```yaml
-ecomscan_cron: true
+ecomscan_cron: false
 ```
-Boolean to set if ecomscan should be run by cron (@Note: This requires a CRON schedule to be installed on your system)
+Boolean to set if ecomscan should be run by cron (@Note: This requires a paid license and a CRON schedule to be installed on your system)
 
 ```yaml
 ecomscan_cron_expr: "0 */4 * * *"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ecomscan_run: true
-ecomscan_cron: true
+ecomscan_cron: false
 ecomscan_cron_expr: "0 */4 * * *"
 ecomscan_binary_download: true
 ecomscan_binary_source: https://ecomscan.com/downloads/linux-amd64/ecomscan
@@ -13,3 +13,4 @@ ecomscan_maximum_filesize: 20000000
 ecomscan_deep: false
 ecomscan_assert_no_malware: false
 ecomscan_assert_no_vulnerabilities: false
+ecomscan_log_file: /var/log/ecomscan.log

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,4 +1,6 @@
-- name: Test
+# Assert that the role can install and execute ecomscan successfully
+# And the role asserts correctly when Malware is detected
+- name: Test Malware Detection
   hosts: all
   pre_tasks:
     - name: Ensure /etc/cron.d/ exists
@@ -33,3 +35,61 @@
 
   roles:
     - { role: samjuk.ecomscan, ecomscan_project_root: /var/www/vhosts/magento2/htdocs }
+
+
+
+# Assert that the cron job is installed successfully, when using a paid license
+- name: Test Cron Installation
+  hosts: clean
+  pre_tasks:
+    - name: Ensure /etc/cron.d/ exists
+      ansible.builtin.file:
+        path: /etc/cron.d/
+        state: directory
+        mode: '0755'
+  post_tasks:
+    - name: Stat Cron File
+      ansible.builtin.stat:
+        path: "/etc/cron.d/ecomscan-{{ inventory_hostname }}"
+      register: cron_check
+    - name: Assert Cron is installed
+      ansible.builtin.assert:
+        that: cron_check.stat.exists
+  roles:
+    - { role: samjuk.ecomscan, ecomscan_project_root: /var/www/vhosts/magento2/htdocs, ecomscan_cron: true, ecomscan_key: "ABCDEFG", ecomscan_run: false }
+
+
+
+
+# Test case for asserting the cron installation cannot be used with a trial key
+# Due to new execution limits introduced by SanSec for free licenses
+- name: Test Cron Installation Error For Trial Key
+  hosts: clean
+  tasks:
+    - name: Ensure /etc/cron.d/ exists
+      ansible.builtin.file:
+        path: /etc/cron.d/
+        state: directory
+        mode: '0755'
+
+    - block:
+        - name: Execute Role
+          register: role_execution
+          ansible.builtin.include_role:
+            name: samjuk.ecomscan
+          vars:
+            ecomscan_project_root: /var/www/vhosts/magento2/htdocs
+            ecomscan_key: "trial"
+            ecomscan_cron: true
+            ecomscan_run: false
+
+        - name: Assertion Failed
+          register: role_completed
+          ansible.builtin.fail:
+            msg: "Role did not fail whilst setting up cron for a trial key"
+      rescue:
+        - name: Assert the role exited after asserting the trial key is in use
+          ansible.builtin.assert:
+            that:
+              - role_execution is defined
+              - role_completed is not defined

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -37,7 +37,6 @@
     - { role: samjuk.ecomscan, ecomscan_project_root: /var/www/vhosts/magento2/htdocs }
 
 
-
 # Assert that the cron job is installed successfully, when using a paid license
 - name: Test Cron Installation
   hosts: clean
@@ -59,8 +58,6 @@
     - { role: samjuk.ecomscan, ecomscan_project_root: /var/www/vhosts/magento2/htdocs, ecomscan_cron: true, ecomscan_key: "ABCDEFG", ecomscan_run: false }
 
 
-
-
 # Test case for asserting the cron installation cannot be used with a trial key
 # Due to new execution limits introduced by SanSec for free licenses
 - name: Test Cron Installation Error For Trial Key
@@ -72,7 +69,8 @@
         state: directory
         mode: '0755'
 
-    - block:
+    - name: Role Block
+      block:
         - name: Execute Role
           register: role_execution
           ansible.builtin.include_role:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,6 +7,5 @@ driver:
 platforms:
   - name: clean
     image: "${MOLECULE_DISTRO:-ubuntu}:${MOLECULE_DISTRO_VER:-latest}"
-
   - name: infected
     image: "${MOLECULE_DISTRO:-ubuntu}:${MOLECULE_DISTRO_VER:-latest}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Notify of Trial License Restriction
+  ansible.builtin.fail:
+    msg: "Sansec has restricted trial keys to 3 total runs. Therefore you need to use a paid license to configure the cron."
+  when: ecomscan_cron and ecomscan_key == 'trial'
+
 - name: Ensure users bin directory exists
   ansible.builtin.file:
     path: "{{ ecomscan_binary_directory }}"
@@ -16,11 +21,14 @@
 - name: Configure Cron
   ansible.builtin.copy:
     content: >
-      {{ ecomscan_cron_expr }} {{ ansible_user | default('root') }} {{ ecomscan_binary_path }}
+      {{ ecomscan_cron_expr }} {{ ansible_user | default('root') }}
+      (
+      date;
+      {{ ecomscan_binary_path }}
       --monitor={{ ecomscan_report_email }}
       --key={{ ecomscan_key }}
       {{ ecomscan_project_root }}
-
+      ) | tee -a /var/log/ecomscan.log
     dest: "/etc/cron.d/ecomscan-{{ inventory_hostname }}"
     mode: "644"
   when: ecomscan_cron


### PR DESCRIPTION
SanSec restricted trial licenses to three executions, making it useless in the context of a cron now.
Reject configuring cron for any hosts with are using a trial license
